### PR TITLE
modify the rule of start key and end key match obj generation

### DIFF
--- a/sdb_idx.h
+++ b/sdb_idx.h
@@ -26,7 +26,7 @@ int sdb_drop_index( const KEY *keyInfo, sdb_cl_auto_ptr cl ) ;
 
 const char *sdb_get_idx_name( KEY *key_info ) ;
 
-int sdb_get_idx_order( KEY * key_info, bson::BSONObj &order ) ;
+int sdb_get_idx_order( KEY * key_info, bson::BSONObj &order, int order_direction) ;
 
 int build_match_obj_by_start_stop_key( uint keynr,
                                        const uchar *key_ptr,
@@ -34,6 +34,7 @@ int build_match_obj_by_start_stop_key( uint keynr,
                                        enum ha_rkey_function find_flag,
                                        key_range *end_range,
                                        TABLE *table,
-                                       bson::BSONObj &matchObj ) ;
+                                       bson::BSONObj &matchObj,
+                                       int *order_direction) ;
 
 #endif


### PR DESCRIPTION
1 modify the rule of match obj generation.  First, conver the mysql search mode to sdb mode. Second, build the start key and end key range match obj.

2 modify the multi column start key and end key search rule.
For key(a,b,c), where a>const1 and b>const1 and c>const.
Start key: a>const1 or a=const1 and b > const2 or a=const1 and b=const2 and c>const3