### PR TITLE
fix bug: in get_unsigned_key_val, uint32 will be cast as sint32.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
+
+
+# Usage: cmake -DSDB_BUILT_IN=ON -DWITH_SDB_DRIVER=/opt/sequoiadb
+#
+# [SDB_BUILT_IN]: compile as built-in plugin or module plugin.
+# [WITH_SDB_DRIVER]: the path to SequoiaDB cpp driver, which must 
+#     contain include/ and lib/libsdbcpp.so
+
 IF(SDB_VER)
   ADD_DEFINITIONS(-DSDB_VER=\"${SDB_VER}\")
 ENDIF()

--- a/ha_sdb.cc
+++ b/ha_sdb.cc
@@ -1594,7 +1594,7 @@ int ha_sdb::get_sharding_key( TABLE *form,
 
                if ( key_part_tmp == key_end_tmp )
                {
-                  rc = SDB_INVALIDARG ;
+                  rc = SDB_ERR_INVALID_ARG ;
                   SDB_PRINT_ERROR( rc,
                                    "The unique index('%-.192s') must include the field: '%-.192s'",
                                    key_info->name, key_part->field->field_name ) ;
@@ -1658,7 +1658,7 @@ int ha_sdb::get_cl_options( TABLE *form,
       }
       if ( beOptions.type() != bson::EOO )
       {
-         rc = SDB_INVALIDARG ;
+         rc = SDB_ERR_INVALID_ARG ;
          SDB_PRINT_ERROR( rc,
                           "Failed to parse cl_options!" ) ;
          goto error ;

--- a/sdb_idx.cc
+++ b/sdb_idx.cc
@@ -39,15 +39,15 @@ enum sdb_search_match_mode
 
 int get_key_direction(sdb_search_match_mode mode)
 {
-	switch (mode)
+   switch (mode)
    {
    case SDB_ET:
-	case SDB_GT:
+   case SDB_GT:
    case SDB_GTE:
-		return 1;
-	case SDB_LT:
-	case SDB_LTE:
-		return -1;
+      return 1;
+   case SDB_LT:
+   case SDB_LTE:
+      return -1;
    default:
       return 1;
    }
@@ -56,20 +56,20 @@ int get_key_direction(sdb_search_match_mode mode)
 
 sdb_search_match_mode conver_search_mode_to_sdb_mode(ha_rkey_function find_flag)
 {
-	switch (find_flag)
+   switch (find_flag)
    {
-	case HA_READ_KEY_EXACT:
+   case HA_READ_KEY_EXACT:
       return SDB_ET;
-	case HA_READ_KEY_OR_NEXT:
+   case HA_READ_KEY_OR_NEXT:
       return SDB_GTE;
-	case HA_READ_AFTER_KEY:		
-		return SDB_GT;
-	case HA_READ_BEFORE_KEY:
+   case HA_READ_AFTER_KEY:      
+      return SDB_GT;
+   case HA_READ_BEFORE_KEY:
       return SDB_LT;
-	case HA_READ_KEY_OR_PREV:
-	case HA_READ_PREFIX_LAST:
-	case HA_READ_PREFIX_LAST_OR_PREV:
-		return SDB_LTE;
+   case HA_READ_KEY_OR_PREV:
+   case HA_READ_PREFIX_LAST:
+   case HA_READ_PREFIX_LAST_OR_PREV:
+      return SDB_LTE;
    case HA_READ_PREFIX:
    default:
       return SDB_UNSUPP;
@@ -253,7 +253,14 @@ void get_unsigned_key_val( const uchar *key_ptr,
          case 3:
          case 4:
             {
-               obj_builder.append( op_str, val_tmp.uint32_val ) ;
+               if( val_tmp.int32_val >= 0 )
+               {
+                  obj_builder.append( op_str, val_tmp.int32_val ) ;
+               }
+               else
+               {
+                  obj_builder.append( op_str, val_tmp.int64_val ) ;
+               }
                break ;
             }
          case 8:
@@ -327,7 +334,7 @@ void get_signed_key_val( const uchar *key_ptr,
             }
          case 8:
             {
-                obj_builder.append( op_str, val_tmp.int64_val ) ;
+               obj_builder.append( op_str, val_tmp.int64_val ) ;
                break ;
             }
          default:


### PR DESCRIPTION
1. fix bug: in get_unsigned_key_val, uint32 will be cast as sint32.
2. add a usage information for CMakeLists.txt.
3. fix wrong error code.
4. convert some tab to space.