### PR TITLE
support character sets other than utf-8

### DIFF
--- a/ha_sdb.h
+++ b/ha_sdb.h
@@ -282,8 +282,7 @@ private:
    bson::BSONObj                             cur_rec ;
    bson::BSONObj                             condition ;
    int                                       keynr ; //use for index_scan
-   uint32                                    str_field_buf_size ;
-   char                                      *str_field_buf ;
+   String                                    conv_str ; //use for converting charset
    SDB_SHARE                                 *share ;
    char                                      db_name[CS_NAME_MAX_SIZE + 1] ;
    char                                      table_name[CL_NAME_MAX_SIZE + 1] ;

--- a/sdb_def.h
+++ b/sdb_def.h
@@ -24,4 +24,6 @@
 
 #define SDB_IDX_FIELD_SIZE_MAX         1024
 
+#define SDB_CHARSET                    my_charset_utf8mb4_bin
+
 #endif

--- a/sdb_util.h
+++ b/sdb_util.h
@@ -18,6 +18,7 @@
 
 #include <pthread.h>
 #include <time.h>
+#include <mysqld.h>
 #include <mysql/psi/mysql_file.h>
 
 int sdb_parse_table_name( const char * from,
@@ -26,6 +27,10 @@ int sdb_parse_table_name( const char * from,
 
 int sdb_get_db_name_from_path( const char * path,
                                char *db_name, int db_name_size ) ;
+
+int sdb_convert_charset( const String &src_str, String &dst_str, 
+                         const CHARSET_INFO *dst_charset ) ;
+
 class sdb_lock_time_out
 {
 public:


### PR DESCRIPTION
sequoiadb is utf-8 database, so all the string should be converted as utf8 before stored. if string is not covertable, error will be thrown.