### PR TITLE
Get variable key with length-bytes.

### DIFF
--- a/sdb_util.h
+++ b/sdb_util.h
@@ -18,7 +18,7 @@
 
 #include <pthread.h>
 #include <time.h>
-#include <mysqld.h>
+#include "sql_class.h"
 #include <mysql/psi/mysql_file.h>
 
 int sdb_parse_table_name( const char * from,


### PR DESCRIPTION
1 In the case of removing spaces filled by mysql, we got the key str with the store_length, while variable key may read more charaters using the store_length. So we use the length_bytes to get the real length of variable-key.

2 fix compile fault in compiling unit-test